### PR TITLE
Fix chain logos when running locally

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -7,6 +7,9 @@ on:
 
 jobs:
   CLAssistant:
+    # Disabled for Hemi as CLA (Contributor License Agreement) is not required.
+    if: false
+
     runs-on: ubuntu-latest
     steps:
       - name: "CLA Assistant"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: "CI"
 # The workflow should be triggered on any push and release events.
 # Release events can push tags (triggering a push event).
 # Therefore:
-#  - docker-publish-staging – is only triggered on push events to main branch
+#  - docker-publish-staging – is only triggered on push events to hemi-main branch
 #  - docker-publish-release – is only triggered on release events
 on:
   push:
@@ -139,7 +139,7 @@ jobs:
         uses: coverallsapp/github-action@v2
 
   docker-publish-staging:
-    if: (github.event_name == 'push' && github.ref == 'refs/heads/main')
+    if: (github.event_name == 'push' && github.ref == 'refs/heads/hemi-main')
     needs: [ flake8, isort, black, django-check ]
     runs-on: ubuntu-latest
     steps:
@@ -161,8 +161,8 @@ jobs:
       - name: Login to DockerHub
         uses: docker/login-action@v3.2.0
         with:
-          username: ${{ secrets.DOCKER_USER }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push
         id: docker_build
         uses: docker/build-push-action@v6.1.0
@@ -173,7 +173,7 @@ jobs:
           build-args: |
             BUILD_NUMBER=${{ env.BUILD_NUMBER }}
             VERSION=${{ github.ref_name }}
-          tags: safeglobal/safe-config-service:staging
+          tags: hemilabs/safe-config-service:staging
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new
       - # Temp fix
@@ -209,8 +209,8 @@ jobs:
       - name: Login to DockerHub
         uses: docker/login-action@v3.2.0
         with:
-          username: ${{ secrets.DOCKER_USER }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push
         id: docker_build
         uses: docker/build-push-action@v6.1.0
@@ -222,8 +222,8 @@ jobs:
             BUILD_NUMBER=${{ env.BUILD_NUMBER }}
             VERSION=${{ github.ref_name }}
           tags: |
-            safeglobal/safe-config-service:${{ github.event.release.tag_name }}
-            safeglobal/safe-config-service:latest
+            hemilabs/safe-config-service:${{ github.event.release.tag_name }}
+            hemilabs/safe-config-service:latest
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new
       - # Temp fix
@@ -239,7 +239,8 @@ jobs:
   autodeploy:
     runs-on: ubuntu-latest
     needs: [docker-publish-staging]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    # Disabled for Hemi
+    if: false
     steps:
     - uses: actions/checkout@v4
     - name: Deploy Staging

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -213,6 +213,8 @@ CGW_SESSION_TIMEOUT_SECONDS = int(os.environ.get("CGW_SESSION_TIMEOUT_SECONDS", 
 MEDIA_ROOT = f"{BASE_DIR}/media/"
 # https://docs.djangoproject.com/en/dev/ref/settings/#media-url
 MEDIA_URL = os.getenv("MEDIA_URL", "/media/")
+# This will override the base URL used to construct the media absolute URLs.
+MEDIA_BASE_URL = os.getenv("MEDIA_BASE_URL", None)
 
 AWS_ACCESS_KEY_ID = os.getenv("AWS_ACCESS_KEY_ID")
 AWS_SECRET_ACCESS_KEY = os.getenv("AWS_SECRET_ACCESS_KEY")


### PR DESCRIPTION
This PR fixes the lookup of chain logos when running the services locally through `docker-compose`. See the comments in the code for details.

It also updates the GitHub Action workflows to match Hemi needs.

Note: CLA Assistant will fail until 1d5e12b is merged.

Fixes https://github.com/hemilabs/safe-wallet-web/issues/4